### PR TITLE
Feature: Implement Parser FFI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
 
-
-
 project(pocket-editor VERSION 0.1.0)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY, "${CMAKE_SOURCE_DIR}/bin")
@@ -36,6 +34,7 @@ corrosion_import_crate(MANIFEST_PATH lib/pocket-compiler/Cargo.toml)
 add_executable(
   pocket-editor
   src/editor.cpp
+  src/compiler.cpp
   include/compiler.hpp
   # Dear ImGui
   lib/imgui/backends/imgui_impl_sdl3.cpp
@@ -50,10 +49,8 @@ add_executable(
   lib/imgui/misc/cpp/imgui_stdlib.cpp
   lib/imgui/misc/cpp/imgui_stdlib.h
   # ImGuiColorTextEdit
-  lib/ImGuiColorTextEdit/TextEditor.cpp
-  lib/ImGuiColorTextEdit/TextEditor.h
-)
-
+  lib/imguicolortextedit/TextEditor.cpp
+  lib/imguicolortextedit/TextEditor.h)
 
 # Include Pocket Compiler bindings for C++.
 target_include_directories(pocket-editor PRIVATE include)
@@ -69,4 +66,3 @@ target_link_libraries(pocket-editor PRIVATE SDL3::SDL3 SDL3_image::SDL3_image)
 
 # Link against the Pocket Compiler.
 target_link_libraries(pocket-editor PUBLIC compiler_ffi)
-

--- a/include/compiler.hpp
+++ b/include/compiler.hpp
@@ -1,4 +1,46 @@
 #pragma once
 
-/** Returns a simple message from the Rust compiler. */
-extern "C" const char *greet(void);
+struct StringHandle final {
+  friend class CompilerHandle;
+  friend class ResultHandle;
+
+private:
+  StringHandle(const char *inner) : inner(inner) {}
+
+public:
+  const char *inner;
+
+  ~StringHandle(void);
+};
+
+class ResultHandle final {
+  friend class CompilerHandle;
+
+private:
+  void *handle;
+
+  ResultHandle(void *handle) : handle(handle) {}
+
+public:
+  ~ResultHandle(void);
+
+  StringHandle module(const char *name, bool *is_err);
+};
+
+class CompilerHandle final {
+private:
+  void *handle;
+
+public:
+  CompilerHandle(void);
+
+  ~CompilerHandle(void);
+
+  bool drop_module(const char *name);
+
+  bool load_module(const char *name, const char *content);
+
+  bool bind_module(const char *name, const char *content);
+
+  ResultHandle try_build(void);
+};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1,0 +1,47 @@
+#include "compiler.hpp"
+
+extern "C" void drop_string(const char *);
+
+extern "C" void drop_result(void *);
+
+extern "C" const char *result_module(void *, const char *, bool *);
+
+extern "C" void *init_compiler(void);
+
+extern "C" void drop_compiler(void *);
+
+extern "C" bool drop_module(void *, const char *);
+
+extern "C" bool load_module(void *, const char *, const char *);
+
+extern "C" bool bind_module(void *, const char *, const char *);
+
+extern "C" void *try_build(void *);
+
+StringHandle::~StringHandle(void) { ::drop_string(this->inner); }
+
+ResultHandle::~ResultHandle(void) { ::drop_result(this->handle); }
+
+StringHandle ResultHandle::module(const char *name, bool *is_err) {
+  return StringHandle(::result_module(this->handle, name, is_err));
+}
+
+CompilerHandle::CompilerHandle(void) { this->handle = init_compiler(); }
+
+CompilerHandle::~CompilerHandle(void) { drop_compiler(this->handle); }
+
+bool CompilerHandle::drop_module(const char *name) {
+  return ::drop_module(this->handle, name);
+}
+
+bool CompilerHandle::load_module(const char *name, const char *content) {
+  return ::load_module(this->handle, name, content);
+}
+
+bool CompilerHandle::bind_module(const char *name, const char *content) {
+  return ::bind_module(this->handle, name, content);
+}
+
+ResultHandle CompilerHandle::try_build(void) {
+  return ResultHandle(::try_build(this->handle));
+}

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -3,7 +3,6 @@
 #include "SDL3/SDL_dialog.h"
 #include "backends/imgui_impl_sdl3.h"
 #include "backends/imgui_impl_sdlrenderer3.h"
-#include "compiler.hpp"
 #include "imgui.h"
 #include <semaphore.h>
 #include <fstream>
@@ -140,7 +139,6 @@ int main(void) {
     }
 
     // Display some standard text, called from the Rust compiler.
-    ImGui::Text("%s", greet());
     editor.Render("TextEditor");
     // Signal to ImGui the end of the current window.
     ImGui::End();


### PR DESCRIPTION
## About

Implements interoperability with the Rust Pocket Compiler.

## Details

Updates the Pocket Compiler git submodule to the most recent build. Will later be moved to `main`.

Implements three types: `CompilerHandle`, `ResultHandle`, and `StringHandle`.

These types are all handles to Rust-allocated types, respectively the compiler instance, an instance of the compiler's build result, and string values.

Each implement constructors and destructors relevant to Rust allocation and deallocation.

The `CompilerHandle` implements four main methods:

- `load_module()` - loads a module and its content into the compiler's memory.
- `bind_module()` - resets the content of a module already loaded into compiler memory.
- `drop_module()` - erases a module from compiler memory.
- `try_build()` - builds all modules contained in memory and returns a `ResultHandle` instance.

The `ResultHandle` implements one main method:

- `module()` - takes in a module name and a pointer to an error checking boolean, and returns a `StringHandle` instance containing either the compilation result or the error response.

The `StringHandle` implements one main field:

- `inner`, used to access the inner string pointer.