### PR TITLE
Smart Instance Handles

### DIFF
--- a/include/compiler.hpp
+++ b/include/compiler.hpp
@@ -1,5 +1,24 @@
 #pragma once
 
+#include <memory>
+#include <utility>
+
+/** Functor for deleting `StringHandle` handles. */
+struct StringHandleDeleter {
+  void operator()(const char *inner) const;
+};
+
+/** Functor for deleting `ResultHandle` handles. */
+struct ResultHandleDeleter {
+  void operator()(void *handle) const;
+};
+
+/** Functor for deleting `CompilerHandle` handles. */
+struct CompilerHandleDeleter {
+  void operator()(void *handle) const;
+};
+
+/** A uniquely owned instance of a Rust-produced string. */
 struct StringHandle final {
   friend class CompilerHandle;
   friend class ResultHandle;
@@ -8,33 +27,53 @@ private:
   StringHandle(const char *inner) : inner(inner) {}
 
 public:
-  const char *inner;
+  std::unique_ptr<const char, StringHandleDeleter> inner;
 
-  ~StringHandle(void);
+  StringHandle(StringHandle const &) = delete;
+
+  StringHandle(StringHandle &&other) : inner(std::move(other.inner)) {}
+
+  StringHandle &operator=(StringHandle const &) = delete;
+
+  StringHandle &operator=(StringHandle &&other);
 };
 
+/** A uniquely owned instance of a compiler build result. */
 class ResultHandle final {
   friend class CompilerHandle;
 
 private:
-  void *handle;
+  std::unique_ptr<void, ResultHandleDeleter> handle;
 
   ResultHandle(void *handle) : handle(handle) {}
 
 public:
-  ~ResultHandle(void);
-
   StringHandle module(const char *name, bool *is_err);
+
+  ResultHandle(ResultHandle const &) = delete;
+
+  ResultHandle(ResultHandle &&other) : handle(std::move(other.handle)) {}
+
+  ResultHandle &operator=(ResultHandle const &) = delete;
+
+  ResultHandle &operator=(ResultHandle &&other);
 };
 
+/** A uniquely owned instance of a compiler from Rust. */
 class CompilerHandle final {
 private:
-  void *handle;
+  std::unique_ptr<void, CompilerHandleDeleter> handle;
 
 public:
   CompilerHandle(void);
 
-  ~CompilerHandle(void);
+  CompilerHandle(CompilerHandle const &) = delete;
+
+  CompilerHandle(CompilerHandle &&other) : handle(std::move(other.handle)) {}
+
+  CompilerHandle &operator=(CompilerHandle const &) = delete;
+
+  CompilerHandle &operator=(CompilerHandle &&other);
 
   bool drop_module(const char *name);
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1,47 +1,79 @@
 #include "compiler.hpp"
+#include <memory>
 
-extern "C" void drop_string(const char *);
+extern "C" {
+void drop_string(const char *);
 
-extern "C" void drop_result(void *);
+void drop_result(void *);
 
-extern "C" const char *result_module(void *, const char *, bool *);
+const char *result_module(void *, const char *, bool *);
 
-extern "C" void *init_compiler(void);
+void *init_compiler(void);
 
-extern "C" void drop_compiler(void *);
+void drop_compiler(void *);
 
-extern "C" bool drop_module(void *, const char *);
+bool drop_module(void *, const char *);
 
-extern "C" bool load_module(void *, const char *, const char *);
+bool load_module(void *, const char *, const char *);
 
-extern "C" bool bind_module(void *, const char *, const char *);
+bool bind_module(void *, const char *, const char *);
 
-extern "C" void *try_build(void *);
-
-StringHandle::~StringHandle(void) { ::drop_string(this->inner); }
-
-ResultHandle::~ResultHandle(void) { ::drop_result(this->handle); }
-
-StringHandle ResultHandle::module(const char *name, bool *is_err) {
-  return StringHandle(::result_module(this->handle, name, is_err));
+void *try_build(void *);
 }
 
-CompilerHandle::CompilerHandle(void) { this->handle = init_compiler(); }
+void StringHandleDeleter::operator()(const char *inner) const {
+  ::drop_string(inner);
+}
 
-CompilerHandle::~CompilerHandle(void) { drop_compiler(this->handle); }
+void ResultHandleDeleter::operator()(void *handle) const {
+  ::drop_result(handle);
+}
+
+void CompilerHandleDeleter::operator()(void *handle) const {
+  ::drop_compiler(handle);
+}
+
+StringHandle &StringHandle::operator=(StringHandle &&other) {
+  if (this != &other) {
+    this->inner = std::move(other.inner);
+  }
+  return *this;
+}
+
+ResultHandle &ResultHandle::operator=(ResultHandle &&other) {
+  if (this != &other) {
+    this->handle = std::move(other.handle);
+  }
+  return *this;
+}
+
+StringHandle ResultHandle::module(const char *name, bool *is_err) {
+  return StringHandle(::result_module(this->handle.get(), name, is_err));
+}
+
+CompilerHandle::CompilerHandle(void) {
+  this->handle = std::unique_ptr<void, CompilerHandleDeleter>(init_compiler());
+}
+
+CompilerHandle &CompilerHandle::operator=(CompilerHandle &&other) {
+  if (this != &other) {
+    this->handle = std::move(other.handle);
+  }
+  return *this;
+}
 
 bool CompilerHandle::drop_module(const char *name) {
-  return ::drop_module(this->handle, name);
+  return ::drop_module(this->handle.get(), name);
 }
 
 bool CompilerHandle::load_module(const char *name, const char *content) {
-  return ::load_module(this->handle, name, content);
+  return ::load_module(this->handle.get(), name, content);
 }
 
 bool CompilerHandle::bind_module(const char *name, const char *content) {
-  return ::bind_module(this->handle, name, content);
+  return ::bind_module(this->handle.get(), name, content);
 }
 
 ResultHandle CompilerHandle::try_build(void) {
-  return ResultHandle(::try_build(this->handle));
+  return ResultHandle(::try_build(this->handle.get()));
 }


### PR DESCRIPTION
## About

Replaces the pointers used within the compiler interop handle structures with unique ones, and moves the destruction code into the `unique_ptr` deleter.

## Considerations

This also involves making all handles move-only types. If shared ownership is needed, consider changing the pointer type to a `shared_ptr` handle instead.